### PR TITLE
Cancel COLLECT_TO_CURSOR event

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,10 @@
             <id>rosewood-repo</id>
             <url>https://repo.rosewooddev.io/repository/public/</url>
         </repository>
+        <repository>
+            <id>enginehub-maven</id>
+            <url>https://maven.enginehub.org/repo/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -144,6 +148,12 @@
             <artifactId>MorePersistentDataTypes</artifactId>
             <version>1.0.0</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldedit</groupId>
+            <artifactId>worldedit-core</artifactId>
+            <version>7.2.0-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Supported Plugins -->

--- a/src/main/java/io/github/sefiraat/danktech2/listeners/CollectToCursorListener.java
+++ b/src/main/java/io/github/sefiraat/danktech2/listeners/CollectToCursorListener.java
@@ -1,0 +1,15 @@
+package io.github.sefiraat.danktech2.listeners;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
+
+public class CollectToCursorListener implements Listener {
+
+    @EventHandler
+    public void onCollect(InventoryClickEvent event) {
+        if (event.getAction() == InventoryAction.COLLECT_TO_CURSOR)
+            event.setCancelled(true);
+    }
+}

--- a/src/main/java/io/github/sefiraat/danktech2/managers/ListenerManager.java
+++ b/src/main/java/io/github/sefiraat/danktech2/managers/ListenerManager.java
@@ -1,6 +1,7 @@
 package io.github.sefiraat.danktech2.managers;
 
 import io.github.sefiraat.danktech2.DankTech2;
+import io.github.sefiraat.danktech2.listeners.CollectToCursorListener;
 import io.github.sefiraat.danktech2.listeners.PackListener;
 import io.github.sefiraat.danktech2.listeners.PickupListener;
 import org.bukkit.event.Listener;
@@ -10,6 +11,7 @@ public class ListenerManager {
     public ListenerManager() {
         addListener(new PickupListener());
         addListener(new PackListener());
+        addListener(new CollectToCursorListener());
     }
 
     private void addListener(Listener listener) {


### PR DESCRIPTION
Attempt at stopping the 'COLLECT_TO_CURSOR' issue. This was the first time I was able to stop the action, and as a bonus, works for both dank and trash packs. Probably a silly way to do this, but I wanted to PR it anyway as it was relatively simple and a small amount of "change" to the code.

Edit: I had to add some things to the pom, as it wasnt picking up sk89q's repo