### PR TITLE
Fix bad duplication bug

### DIFF
--- a/src/main/java/io/github/sefiraat/danktech2/core/DankGUI.java
+++ b/src/main/java/io/github/sefiraat/danktech2/core/DankGUI.java
@@ -82,6 +82,7 @@ public class DankGUI extends ChestMenu {
         }
 
         // Don't let players shift click into the GUI to bypass the handler
+        // Also don't allow clicks on items that the pack contains; this allows for item duplication
         addPlayerInventoryClickHandler((p, slot, item, action) ->
                 !action.isShiftClicked() && Arrays.stream(packInstance.getItems())
                         .noneMatch(packItem -> packItem != null && item != null && packItem.getType() == item.getType()));

--- a/src/main/java/io/github/sefiraat/danktech2/core/DankGUI.java
+++ b/src/main/java/io/github/sefiraat/danktech2/core/DankGUI.java
@@ -20,6 +20,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.text.MessageFormat;
+import java.util.Arrays;
+
 
 public class DankGUI extends ChestMenu {
 
@@ -80,7 +82,9 @@ public class DankGUI extends ChestMenu {
         }
 
         // Don't let players shift click into the GUI to bypass the handler
-        addPlayerInventoryClickHandler((p, slot, item, action) -> !action.isShiftClicked());
+        addPlayerInventoryClickHandler((p, slot, item, action) ->
+                !action.isShiftClicked() && Arrays.stream(packInstance.getItems())
+                        .noneMatch(packItem -> packItem != null && item != null && packItem.getType() == item.getType()));
         setupAllItems();
     }
 

--- a/src/main/java/io/github/sefiraat/danktech2/core/DankGUI.java
+++ b/src/main/java/io/github/sefiraat/danktech2/core/DankGUI.java
@@ -83,9 +83,11 @@ public class DankGUI extends ChestMenu {
 
         // Don't let players shift click into the GUI to bypass the handler
         // Also don't allow clicks on items that the pack contains; this allows for item duplication
-        addPlayerInventoryClickHandler((p, slot, item, action) ->
-                !action.isShiftClicked() && Arrays.stream(packInstance.getItems())
-                        .noneMatch(packItem -> packItem != null && item != null && packItem.getType() == item.getType()));
+        addPlayerInventoryClickHandler((p, slot, item, action) -> {
+            p.closeInventory();
+            return !action.isShiftClicked() && Arrays.stream(packInstance.getItems())
+                    .noneMatch(packItem -> packItem != null && item != null && packItem.getType() == item.getType());
+        });
         setupAllItems();
     }
 

--- a/src/main/java/io/github/sefiraat/danktech2/core/DankGUI.java
+++ b/src/main/java/io/github/sefiraat/danktech2/core/DankGUI.java
@@ -84,7 +84,6 @@ public class DankGUI extends ChestMenu {
         // Don't let players shift click into the GUI to bypass the handler
         // Also don't allow clicks on items that the pack contains; this allows for item duplication
         addPlayerInventoryClickHandler((p, slot, item, action) -> {
-            p.closeInventory();
             return !action.isShiftClicked() && Arrays.stream(packInstance.getItems())
                     .noneMatch(packItem -> packItem != null && item != null && packItem.getType() == item.getType());
         });
@@ -176,7 +175,7 @@ public class DankGUI extends ChestMenu {
             }
         }
 
-        return false;
+        return true;
     }
 
     private void withdrawOne(Player player, int instanceSlot) {

--- a/src/main/java/io/github/sefiraat/danktech2/core/TrashGUI.java
+++ b/src/main/java/io/github/sefiraat/danktech2/core/TrashGUI.java
@@ -56,7 +56,7 @@ public class TrashGUI extends ChestMenu {
     private final TrashPack trashPack;
 
     public TrashGUI(TrashPackInstance packInstance, ItemStack itemStack) {
-        super("Dank Pack - Tier " + packInstance.getTier());
+        super("Trash Pack - Tier " + packInstance.getTier());
         this.packInstance = packInstance;
         this.itemStack = itemStack;
         this.trashPack = (TrashPack) SlimefunItem.getByItem(itemStack);

--- a/src/main/java/io/github/sefiraat/danktech2/core/TrashGUI.java
+++ b/src/main/java/io/github/sefiraat/danktech2/core/TrashGUI.java
@@ -19,6 +19,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.text.MessageFormat;
+import java.util.Arrays;
+
 
 public class TrashGUI extends ChestMenu {
 
@@ -69,7 +71,10 @@ public class TrashGUI extends ChestMenu {
         }
 
         // Don't let players shift click into the GUI to bypass the handler
-        addPlayerInventoryClickHandler((p, slot, item, action) -> !action.isShiftClicked());
+        // Also don't allow clicks on items that the pack contains; this allows for item duplication
+        addPlayerInventoryClickHandler((p, slot, item, action) ->
+                !action.isShiftClicked() && Arrays.stream(packInstance.getItems())
+                        .noneMatch(packItem -> packItem != null && item != null && packItem.getType() == item.getType()));
         setupAllItems();
     }
 


### PR DESCRIPTION
Fixes a bug that lets you duplicate arbitrary items with ridiculous ease. Won't go into more detail here for obvious reasons.

Also tiny thing but renamed the trash pack's GUI name from 'Dank Pack' to 'Trash Pack'